### PR TITLE
add blacklist option for group cache setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,36 @@ Usage:
 \Geniem\GroupCache::delete_group( $group_key );
 ```
 
-## Excluding groups from caching
+## Excluding custom or including default groups to caching
 
-The Redis dropin automatically caches all data stored with WordPress Object Cache into Redis. If you want to exclude some groups from being stored into the group cache, return `true` from the `no_group_cache` filter for the corresponding group key.
+The Redis dropin automatically caches all data stored with WordPress Object Cache into Redis. If you want to modify which groups are stored you can use the two filters `geniem/cache/no_group_cache/blacklist` and `geniem/cache/no_group_cache`
 
+### Modifying the blacklist
+If you want to include some default groups like `acf` or `transient` or exclude custom ones for example from plugins that use it you can use the `geniem/cache/no_group_cache/blacklist` filter to modify an array of blacklisted groups.
+```php
+function group_cache_blacklist( array $groups ) : array {
+	$groups[] = 'customgroup';
+	return $groups;
+}
+add_filter( 'geniem/cache/no_group_cache/blacklist', 'group_cache_blacklist', 1, 1 );
 ```
-function no_group_cache( $group, $key ) {
+
+#### Exluded groups by default
+- acf
+- posts
+- terms
+- options
+- dustpress/rendered
+- transient
+- default
+
+### More specific selection if a group should be excluded
+
+You can do a more direct check if a group should be exluded by using the `geniem/cache/no_group_cache` filter.
+_Note this is applied after the blacklist check, so if the group is already on the blacklist this wont be checked._
+
+```php
+function no_group_cache( string $group, string $key ) : bool {
     if ( 'no_caching_key' === $group ) {
         return true;
     } else {

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Usage:
 
 ## Excluding custom or including default groups to caching
 
-The Redis dropin automatically caches all data stored with WordPress Object Cache into Redis. If you want to modify which groups are stored you can use the two filters `geniem/cache/no_group_cache/blacklist` and `geniem/cache/no_group_cache`
+The Redis dropin automatically caches all data stored with WordPress Object Cache into Redis. If you want to modify which groups are stored you can use the two filters `geniem/cache/no_group_cache/blacklist` and `geniem/cache/no_group_cache`.
 
 ### Modifying the blacklist
-If you want to include some default groups like `acf` or `transient` or exclude custom ones for example from plugins that use it you can use the `geniem/cache/no_group_cache/blacklist` filter to modify an array of blacklisted groups.
+If you want to include some default groups like `acf` or `transient` or exclude custom ones for example from plugins that use it, you can use the `geniem/cache/no_group_cache/blacklist` filter to modify an array of blacklisted groups.
 ```php
 function group_cache_blacklist( array $groups ) : array {
 	$groups[] = 'customgroup';
@@ -60,7 +60,7 @@ add_filter( 'geniem/cache/no_group_cache/blacklist', 'group_cache_blacklist', 1,
 ### More specific selection if a group should be excluded
 
 You can do a more direct check if a group should be exluded by using the `geniem/cache/no_group_cache` filter.
-_Note this is applied after the blacklist check, so if the group is already on the blacklist this wont be checked._
+_Note this is applied after the blacklist check, so if the group is already on the blacklist this will not be checked._
 
 ```php
 function no_group_cache( string $group, string $key ) : bool {

--- a/classes/cache.php
+++ b/classes/cache.php
@@ -105,13 +105,23 @@ class GroupCache {
      */
     public static function no_group_cache( $group, $key ) {
 
-        // Ignore empty and default groups.
-        if ( empty( $group ) ) { return true; }
-        if ( 'default' === $group ) { return true; }
+        // Group blacklist
+        $blacklist = apply_filters( 'geniem/cache/no_group_cache/blacklist', [
+            'acf',
+            'posts',
+            'terms',
+            'options',
+            'dustpress/rendered',
+            'transient',
+            'default',
+        ]);
 
-        // Filter the condition.
-        $condition = apply_filters( 'geniem/cache/no_group_cache', false, $group, $key );
+        $no_group_cache = (
+            empty( $group ) || // No group
+            in_array( $group, $blacklist, true ) || // Group is in blacklist
+            apply_filters( 'geniem/cache/no_group_cache', false, $group, $key ) // Failed specific check
+        );
 
-        return $condition;
+        return $no_group_cache;
     }
 }


### PR DESCRIPTION
This adds the options to blacklist certain groups from being added into the group cache with some sane defaults.